### PR TITLE
Make owner an optional flag in the runners command

### DIFF
--- a/cmd/runners.go
+++ b/cmd/runners.go
@@ -47,10 +47,6 @@ func runRunnersE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if len(owner) == 0 {
-		return fmt.Errorf("owner is required")
-	}
-
 	if len(pat) == 0 {
 		return fmt.Errorf("pat is required")
 	}
@@ -68,7 +64,6 @@ func runRunnersE(cmd *cobra.Command, args []string) error {
 	}
 
 	if requestJson {
-
 		var prettyJSON bytes.Buffer
 		err := json.Indent(&prettyJSON, []byte(res), "", "  ")
 		if err != nil {

--- a/pkg/client.go
+++ b/pkg/client.go
@@ -82,7 +82,10 @@ func (c *Client) ListRunners(patStr string, owner string, staff bool, json bool)
 		q.Set("staff", "1")
 	}
 
-	q.Set("owner", owner)
+	if len(owner) > 0 {
+		q.Set("owner", owner)
+	}
+
 	u.RawQuery = q.Encode()
 
 	req, err := http.NewRequest(http.MethodGet, u.String(), nil)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Make the owner flag optional for the runner command. All runners for a customer are returned when the flag is not set. 

The owner flag could be used to filter runners for a specific customer. The Actuated control plane will need to be updated to support filtering runners.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The owner flag was required but ignored. The command always returns all runners for orgs the access token owner is a member of.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Verified the command can be used without the `owner` flag and runners for the correct orgs are returned.

Verified the command is working against an updated version of the controller that supports filtering.

<img width="1192" alt="Screenshot 2023-07-20 at 09 00 57" src="https://github.com/self-actuated/actuated-cli/assets/16267532/18edd342-2acc-4d69-a8d3-d21f1f744b18">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.