### PR TITLE
Add --verbose runner output option with OS included

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ actuated-cli jobs actuated-samples
 
 ```bash
 actuated-cli runners actuated-samples
+
+# Include the operating system reported by each agent
+actuated-cli runners --verbose actuated-samples
 ```
 
 ## View SSH sessions available:

--- a/cmd/runners.go
+++ b/cmd/runners.go
@@ -22,6 +22,9 @@ func makeRunners() *cobra.Command {
   # List runners for all customers
   actuated-cli runners --staff OWNER
 
+  # Include the operating system in the table
+  actuated-cli runners --verbose OWNER
+
   # List runners in JSON format
   actuated-cli runners --json OWNER
 `,
@@ -30,6 +33,7 @@ func makeRunners() *cobra.Command {
 	cmd.RunE = runRunnersE
 
 	cmd.Flags().Bool("images", false, "Show the image being used for the rootfs and Kernel")
+	cmd.Flags().BoolP("verbose", "v", false, "Show additional runner details")
 	cmd.Flags().BoolP("json", "j", false, "Request output in JSON format")
 
 	return cmd
@@ -56,6 +60,10 @@ func runRunnersE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	verbose, err := cmd.Flags().GetBool("verbose")
+	if err != nil {
+		return err
+	}
 
 	requestJson, err := cmd.Flags().GetBool("json")
 	if err != nil {
@@ -68,7 +76,7 @@ func runRunnersE(cmd *cobra.Command, args []string) error {
 
 	c := pkg.NewClient(http.DefaultClient, os.Getenv("ACTUATED_URL"))
 
-	res, status, err := c.ListRunners(pat, owner, staff, images, requestJson)
+	res, status, err := c.ListRunners(pat, owner, staff, images, verbose, requestJson)
 	if err != nil {
 		return err
 	}

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -86,7 +86,7 @@ func runUpgradeE(cmd *cobra.Command, args []string) error {
 	var upgradeHosts []Host
 	if allHosts {
 		includeImages := false
-		hosts, httpStatus, err := c.ListRunners(pat, owner, staff, includeImages, true)
+		hosts, httpStatus, err := c.ListRunners(pat, owner, staff, includeImages, false, true)
 		if err != nil {
 			return err
 		}

--- a/pkg/client.go
+++ b/pkg/client.go
@@ -133,7 +133,7 @@ func (c *Client) GetBuildIncreases(patStr string, owner string, startDate time.T
 	return string(body), res.StatusCode, nil
 }
 
-func (c *Client) ListRunners(patStr string, owner string, staff, images, json bool) (string, int, error) {
+func (c *Client) ListRunners(patStr string, owner string, staff, images, verbose, json bool) (string, int, error) {
 
 	u, _ := url.Parse(c.baseURL)
 	u.Path = "/api/v1/runners"
@@ -145,6 +145,10 @@ func (c *Client) ListRunners(patStr string, owner string, staff, images, json bo
 
 	if images {
 		q.Set("images", "1")
+	}
+
+	if verbose {
+		q.Set("verbose", "1")
 	}
 
 	if len(owner) > 0 {

--- a/pkg/client_runners_test.go
+++ b/pkg/client_runners_test.go
@@ -1,0 +1,36 @@
+package pkg
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestListRunnersRequestsVerboseOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.Path, "/api/v1/runners"; got != want {
+			t.Fatalf("want path %q, got %q", want, got)
+		}
+		if got, want := r.URL.Query().Get("owner"), "alexellis"; got != want {
+			t.Fatalf("want owner %q, got %q", want, got)
+		}
+		if got, want := r.URL.Query().Get("verbose"), "1"; got != want {
+			t.Fatalf("want verbose %q, got %q", want, got)
+		}
+		if got := r.Header.Get("Accept"); got != "" {
+			t.Fatalf("want plain-text Accept header, got %q", got)
+		}
+		io.WriteString(w, "table")
+	}))
+	defer server.Close()
+
+	client := NewClient(server.Client(), server.URL)
+	body, status, err := client.ListRunners("token", "alexellis", false, false, true, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status != http.StatusOK || body != "table" {
+		t.Fatalf("want 200 and table, got %d and %q", status, body)
+	}
+}


### PR DESCRIPTION
## Summary

- add `-v`/`--verbose` to `actuated-cli runners`
- request the controller's expanded runner table containing OS
- preserve the existing default table and JSON output
- document and test the verbose API query

Depends on the controller change in openfaasltd/actuated#186.

## Testing

- `go test ./...`
- `go build ./...`
- `gofmt -l` returned no changed Go files
- `git diff --check`